### PR TITLE
Downgrade python to 3.9.7 and fix alpine version in tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-    # Matching tags: 3.8.2-1.14.3-1.30.0, etc.
+    # Matching tags: 3.9.7-1.14-1.41.1, etc.
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+-[0-9]+.[0-9]+.[0-9]+-[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-[0-9]+.[0-9]+-[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     types: [opened, ready_for_review, reopened, synchronize]
     paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0-alpine3.14
+FROM python:3.9.7-alpine3.14
 
 RUN apk add --no-cache \
   # required by grpc


### PR DESCRIPTION
Downgrading python as 3.10 is not fully supported by our dependencies.
https://github.com/basisai/span/pull/3412