### PR TITLE
Bump Python 3.9.7 to 3.9.9 for alpine 3.14.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7-alpine3.14
+FROM python:3.9.9-alpine3.14
 
 RUN apk add --no-cache \
   # required by grpc


### PR DESCRIPTION
```
➜ docker run -it --rm python:3.9.7-alpine3.14 sh
/ # cat /etc/alpine-release
3.14.2

➜ docker run -it --rm python:3.9.9-alpine3.14 sh  
/ # cat /etc/alpine-release 
3.14.3
```

`3.9.7-alpine3.14` is not rebuilt for vulnerability fixes. Bump to `python:3.9.9-alpine3.14` which has these fixes included.

- https://www.alpinelinux.org/posts/Alpine-3.14.3-released.html
- https://hub.docker.com/layers/python/library/python/3.9.7-alpine3.14/images/sha256-7821b05028a658d988bf63c525a9bc7d5eecc56df6da6f45430807aa50d2f734?context=explore
- https://hub.docker.com/layers/python/library/python/3.9.9-alpine3.14/images/sha256-cdb4d8e261e91946e5788a32b1422f1d8724b8ab0a651e6f9c340c88d108263d?context=explore