### PR TITLE
Bump to python 3.9.10 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.9-alpine3.15
+FROM python:3.9.10-alpine3.15
 
 RUN apk add --no-cache \
   # required by grpc


### PR DESCRIPTION
contains security update for expat 2.4.3 https://teamcity.amoy.ai/buildConfiguration/Span_Api_BuildDockerImage/146719

```bash
~/w/python-alpine-grpcio (expat|✔) $ docker run -it python:3.9.10-alpine3.15 sh
/ # apk list | grep expat
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/main: No such file or directory
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/community: No such file or directory
expat-2.4.3-r0 aarch64 {expat} (MIT) [installed]
```